### PR TITLE
Support rbxassetid:// paths

### DIFF
--- a/src/rbxm-suite.lua
+++ b/src/rbxm-suite.lua
@@ -388,7 +388,12 @@ function rbxmSuite.launch(location, options)
 
 	local clock = os.clock()
 
-	local objects = game:GetObjects(fileAsContent(location))
+	local objects
+	if string.find(location, "^rbxassetid://") then
+		objects = game:GetObjects(location)
+	else
+		objects = game:GetObjects(fileAsContent(location))
+	end
 	assert(type(objects) == "table", objects or "Failed to load model at " .. location)
 	assert(typeof(objects[1]) == "Instance", "Model must contain at least one instance")
 


### PR DESCRIPTION
In my current workflow, I have a model that can be accessed on a roblox server through InsertService, but I also want to be able to load it from the client. In Synapse X and Script-Ware, `game:GetObjects` supports using `rbxassetid://` links, but rbxm-suite would throw an error when using `launch()`. It's a simple fix, and could perhaps be implemented for the [rest of the protocols](https://developer.roblox.com/en-us/articles/Content#protocols), but I haven't looked into the others.